### PR TITLE
fix pip failing in virtualenv under SCL

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -117,7 +117,7 @@ define python::pip (
 
   $pip_env = $virtualenv ? {
     'system' => "${exec_prefix}pip",
-    default  => "${virtualenv}/bin/pip",
+    default  => "${exec_prefix}${virtualenv}/bin/pip",
   }
 
   $pypi_index = $index ? {


### PR DESCRIPTION
When a virtualenv is created from an SCL python installation, that python binary needs to be runnable for commands in that virtualenv to work. At present this will fail if there is not a matching version of libpython installed in a system path. (Example: python3 is installed via SCL on a system without any version of python3 installed in the base system.) "scl enable" among other things, sets LD_LIBRARY_PATH, and thus needs to be invoked when running pip.
